### PR TITLE
feat(nasa-service): consumir endpoint APOD con parámetros api_key y f…

### DIFF
--- a/src/app/nasa/components/apod/apod.component.html
+++ b/src/app/nasa/components/apod/apod.component.html
@@ -1,11 +1,11 @@
 <div>
-    <h1 class="text-center">ADN</h1>
-    <div class="img-container">
-        <img class="responsive-img" src="{{apod?.url}}" alt="">
-    </div>
-    <h3 class="text-center">APOD</h3>
-    <div class="container">
-        <h4>{{apod?.title}}</h4>
-        <p>{{apod?.explanation}}</p>
-    </div>
+  <h1 class="text-center">ADN</h1>
+  <div class="img-container">
+    <img class="responsive-img" src="{{ apod?.url }}" alt="" />
+  </div>
+  <h3 class="text-center">APOD</h3>
+  <div class="container">
+    <h4>{{ apod?.title }}</h4>
+    <p>{{ apod?.explanation }}</p>
+  </div>
 </div>

--- a/src/app/nasa/components/apod/apod.component.ts
+++ b/src/app/nasa/components/apod/apod.component.ts
@@ -1,23 +1,19 @@
-import { Component, AfterViewInit, OnInit } from '@angular/core';
-import { NasaService } from '../../services/nasa.service';
+import {Component, AfterViewInit, OnInit} from '@angular/core'
+import {NasaService} from '../../services/nasa.service'
 
 @Component({
   selector: 'app-apod',
   templateUrl: './apod.component.html',
-  styleUrls: ['./apod.component.css']
+  styleUrls: ['./apod.component.css'],
 })
 export class ApodComponent {
-
-  constructor(private nasaService: NasaService) {
-
-  }
+  constructor(private nasaService: NasaService) {}
 
   ngOnInit() {
-    this.nasaService.getApod();
+    this.nasaService.getApod()
   }
 
-  get apod () {
-    return this.nasaService.apod;
+  get apod() {
+    return this.nasaService.apod
   }
-
 }

--- a/src/app/nasa/services/nasa.service.ts
+++ b/src/app/nasa/services/nasa.service.ts
@@ -1,23 +1,46 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { Neo } from '../interfaces/nasa.interfaces';
+import {HttpClient, HttpHeaders, HttpParams} from '@angular/common/http'
+import {Injectable} from '@angular/core'
+import {Neo} from '../interfaces/nasa.interfaces'
+import {catchError, throwError} from 'rxjs'
+
+interface Apod {}
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class NasaService {
-
-  private _dates: any[] = [];
+  private _dates: any[] = []
   private _apodObj: any
+  private _apiKey: string = 'LZ4zl3U03iPqY14cRyc4bpK5eq0LnUIswS7B1SrE'
+  private _api: string = 'https://api.nasa.gov/planetary'
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   get dates() {
-    return [...this._dates];
+    return [...this._dates]
   }
 
   get apod() {
-    return this._apodObj;
+    return this._apodObj
+  }
+
+  private getRandom1to7(): number {
+    return Math.floor(Math.random() * 7) + 1
+  }
+
+  private getRandomDateFromLast7Days(offsetDays: number): string {
+    // 1. Obtener la fecha actual
+    const today = new Date()
+
+    // 2. Restar los días aleatorios (valor obtenido en Paso 1)
+    today.setDate(today.getDate() - offsetDays)
+
+    // 3. Formatear a YYYY-MM-DD (formato que pide la API)
+    const year = today.getFullYear()
+    const month = String(today.getMonth() + 1).padStart(2, '0')
+    const day = String(today.getDate()).padStart(2, '0')
+
+    return `${year}-${month}-${day}`
   }
 
   getApod() {
@@ -26,7 +49,7 @@ export class NasaService {
      * Almacene en una variable un número aleatorio entre 1 y 7
      */
 
-    
+    const offsetDays = this.getRandom1to7()
 
     /**
      * Paso 2
@@ -34,8 +57,8 @@ export class NasaService {
      * Obtenga y almacene en una variable la fecha actual
      * A los días de la fecha actual le debe restar el número obtenido en el Paso 1 para obtener una fecha aleatoria de los últimos 7 días
      */
-    
 
+    const randomDate = this.getRandomDateFromLast7Days(offsetDays)
 
     /**
      * Paso 3
@@ -46,11 +69,25 @@ export class NasaService {
      * Debe asignar el valor de la respuesta del endpoint a la variable global _apod que ya se encuentra declarada, ejemplo: this._apodObj = respuesta;
      */
 
-    
+    const params = new HttpParams()
+      .set('api_key', this._apiKey)
+      .set('date', randomDate)
+
+    // headers opcionales
+    const headers = new HttpHeaders().set('Accept', 'application/json')
+
+    return this.http
+      .get<Apod>(`${this._api}/apod`, {params, headers})
+      .subscribe({
+        next: a => (this._apodObj = a),
+        error: error => {
+          console.log('get error apod')
+        },
+      })
   }
 
   /**
-   * 
+   *
    * @param date Fecha seleccionada en el input date
    */
   buscarNeo(date: string) {
@@ -64,7 +101,5 @@ export class NasaService {
      * Nota: para start_date y end_date se utiliza el mismo valor el cual llega como parámetro de la función.
      * Debe asignar el valor de la respuesta del endpoint a la variable global _dates, ejemplo: this._dates = respuesta.near_earth_objects[date], siendo [date] el parámetro que recibe la función;
      */
-
-
   }
 }


### PR DESCRIPTION
##  Resumen del Pull Request
Este PR implementa la funcionalidad para **consumir el endpoint APOD de la NASA** desde el servicio `nasa.service.ts`.

###  Cambios principales
- Se agregó la función `getApod()` que realiza la petición al endpoint `https://api.nasa.gov/planetary/apod`.  
- Se integraron los parámetros requeridos: `api_key` y `date`.  
- Se generó una fecha aleatoria dentro de los últimos 7 días para la consulta.  

###  Resultado
Al ejecutar la aplicación, se muestra en el `localhost` la información retornada por el endpoint (título, fecha, imagen/video y explicación).  
<img width="1487" height="1320" alt="Screenshot 2025-09-22 at 1 45 40 PM" src="https://github.com/user-attachments/assets/50a597df-76f8-46c7-a3dc-b9db1bb792e1" />

